### PR TITLE
Fix l'affichage du temps restant au dessus d'une heure

### DIFF
--- a/src/main/java/fr/synchroneyes/mineral/Utils/TimeConverter.java
+++ b/src/main/java/fr/synchroneyes/mineral/Utils/TimeConverter.java
@@ -1,10 +1,10 @@
 package fr.synchroneyes.mineral.Utils;
 
 public class TimeConverter {
-    public static String intToString(int valeur) {
+    public static String intToString(int valeurEnSecondes) {
         int minutes, secondes;
-        minutes = (valeur % 3600) / 60;
-        secondes = valeur % 60;
+        minutes = valeurEnSecondes / 60;
+        secondes = valeurEnSecondes % 60;
         return String.format("%02d:%02d", minutes, secondes);
 
     }


### PR DESCRIPTION
Bonjour !
Cette PR modifie juste le formatage du temps restant pour éviter le retour à 0 quand le temps est supérieur à 1 heure !
Je pense que cette feature était intentionnelle, mais beaucoup de joueurs sont confus quand le timer repasse de "0 minutes" à "60 minutes"

Exemple avec 90 minutes (1h30):
Avant: "Temps restant: 30 minutes", après 30 minutes: "Temps restant: 60 minutes"
Après: "Temps restant: 90 minutes"